### PR TITLE
Fix: Status for Bots with 0 integrations, added Branch to status view

### DIFF
--- a/lib/xcskarel/application.rb
+++ b/lib/xcskarel/application.rb
@@ -52,7 +52,7 @@ module XCSKarel
     def self.colorize(key, value)
       value ||= ""
       case key
-      when "integration_step"
+      when "current_step"
         case value
         when "completed"
           value = value.white
@@ -61,7 +61,7 @@ module XCSKarel
         else
           value = value.yellow
         end
-      when "integration_result"
+      when "result"
         case value
         when "succeeded"
           value = value.green

--- a/lib/xcskarel/config.rb
+++ b/lib/xcskarel/config.rb
@@ -14,6 +14,14 @@ module XCSKarel
       (config_json['name'] || File.basename(@path).split('.').first).gsub("botconfig_", "")
     end
 
+    def branch
+      blueprint = @json['configuration']['sourceControlBlueprint']
+      primary_repo_key = blueprint['DVTSourceControlWorkspaceBlueprintPrimaryRemoteRepositoryKey']
+      location = blueprint['DVTSourceControlWorkspaceBlueprintLocationsKey'][primary_repo_key]
+      # might be nil if we're pointing to a commit, for instance.
+      return location['DVTSourceControlBranchIdentifierKey']
+    end
+
     def original_bot_name
       @json['name'] || config_json['original_bot_name']
     end


### PR DESCRIPTION
- added branch to the status table
- fixed status fetching when a bot doesn't yet have any integrations
